### PR TITLE
Add CORS preflight handlers to the jobs routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-*
+* OPTIONS handlers on every `/jobs` and `/jobs/<id>/...` route so browsers can complete the CORS preflight and reach the job status, cancel and files endpoints directly from a different origin, matching the pattern already in place for the `/nodes/<id>/print` routes.
 
 ### Changed
 

--- a/src/colony_print/controllers/job.py
+++ b/src/colony_print/controllers/job.py
@@ -13,10 +13,18 @@ class JobController(appier.Controller):
     def list(self):
         return dict(self.owner.jobs_info)
 
+    @appier.route("/jobs", "OPTIONS")
+    def list_o(self):
+        return ""
+
     @appier.route("/jobs/<str:id>", "GET", json=True)
     @appier.ensure(token="admin")
     def show(self, id):
         return self.owner.jobs_info[id]
+
+    @appier.route("/jobs/<str:id>", "OPTIONS")
+    def show_o(self, id):
+        return ""
 
     @appier.route("/jobs/<str:id>/cancel", "POST", json=True)
     @appier.ensure(token="admin")
@@ -48,6 +56,10 @@ class JobController(appier.Controller):
         job_info.update(status="cancelled", cancel_time=time.time())
         return job_info
 
+    @appier.route("/jobs/<str:id>/cancel", "OPTIONS")
+    def cancel_o(self, id):
+        return ""
+
     @appier.route("/jobs/<str:id>/files", "GET", json=True)
     @appier.ensure(token="admin")
     def files(self, id):
@@ -60,6 +72,10 @@ class JobController(appier.Controller):
             for name in sorted(os.listdir(job_path))
         ]
 
+    @appier.route("/jobs/<str:id>/files", "OPTIONS")
+    def files_o(self, id):
+        return ""
+
     @appier.route("/jobs/<str:id>/files/<str:name>", "GET")
     @appier.ensure(token="admin")
     def file(self, id, name):
@@ -71,3 +87,7 @@ class JobController(appier.Controller):
             code=404,
         )
         return self.send_path(file_path)
+
+    @appier.route("/jobs/<str:id>/files/<str:name>", "OPTIONS")
+    def file_o(self, id, name):
+        return ""

--- a/src/colony_print/test/controllers/job.py
+++ b/src/colony_print/test/controllers/job.py
@@ -22,18 +22,68 @@ class JobControllerTest(unittest.TestCase):
         response = self.app.get("/jobs")
         self.assertEqual(response.code, 403)
 
+    def test_list_o(self):
+        response = self.app.options("/jobs")
+        self.assertEqual(response.code, 200)
+        self.assertEqual(
+            response.headers["Access-Control-Allow-Origin"].startswith("*"), True
+        )
+        self.assertEqual(
+            response.headers["Access-Control-Allow-Headers"].startswith("*"), True
+        )
+
     def test_show(self):
         response = self.app.get("/jobs/name")
         self.assertEqual(response.code, 403)
+
+    def test_show_o(self):
+        response = self.app.options("/jobs/name")
+        self.assertEqual(response.code, 200)
+        self.assertEqual(
+            response.headers["Access-Control-Allow-Origin"].startswith("*"), True
+        )
+        self.assertEqual(
+            response.headers["Access-Control-Allow-Headers"].startswith("*"), True
+        )
 
     def test_cancel(self):
         response = self.app.post("/jobs/name/cancel")
         self.assertEqual(response.code, 403)
 
+    def test_cancel_o(self):
+        response = self.app.options("/jobs/name/cancel")
+        self.assertEqual(response.code, 200)
+        self.assertEqual(
+            response.headers["Access-Control-Allow-Origin"].startswith("*"), True
+        )
+        self.assertEqual(
+            response.headers["Access-Control-Allow-Headers"].startswith("*"), True
+        )
+
     def test_files(self):
         response = self.app.get("/jobs/name/files")
         self.assertEqual(response.code, 403)
 
+    def test_files_o(self):
+        response = self.app.options("/jobs/name/files")
+        self.assertEqual(response.code, 200)
+        self.assertEqual(
+            response.headers["Access-Control-Allow-Origin"].startswith("*"), True
+        )
+        self.assertEqual(
+            response.headers["Access-Control-Allow-Headers"].startswith("*"), True
+        )
+
     def test_file(self):
         response = self.app.get("/jobs/name/files/file.txt")
         self.assertEqual(response.code, 403)
+
+    def test_file_o(self):
+        response = self.app.options("/jobs/name/files/file.txt")
+        self.assertEqual(response.code, 200)
+        self.assertEqual(
+            response.headers["Access-Control-Allow-Origin"].startswith("*"), True
+        )
+        self.assertEqual(
+            response.headers["Access-Control-Allow-Headers"].startswith("*"), True
+        )


### PR DESCRIPTION
## Summary

- Adds empty `OPTIONS` handlers for `/jobs`, `/jobs/<id>`, `/jobs/<id>/cancel`, `/jobs/<id>/files` and `/jobs/<id>/files/<name>` in `controllers/job.py`. Appier wraps these with the standard `Access-Control-Allow-Origin: *` and `Access-Control-Allow-Headers: *` response, so a browser sending a custom `X-Secret-Key` header on a cross-origin request can complete the preflight.
- Mirrors the existing `test_print_default_o` pattern with one preflight test per new handler so the open allow-origin / allow-headers contract is locked into the suite.
- Adds a single bullet under `[Unreleased] / Added` in `CHANGELOG.md` summarising the change for downstream consumers.

The signatur print job indicator (hivesolutions/signatur#50) hit a CORS preflight failure against `/jobs/<id>` when polling from a different origin; this change unblocks that integration without touching the existing `/nodes/<id>/print` route which already had its own OPTIONS handler.

## Test plan

- [x] `black .` reports nothing to change.
- [x] `PYTHONPATH=src .venv/bin/python -m pytest src/colony_print/test` — 16 passing including the 5 new `*_o` tests.
- [x] Browser preflight on `OPTIONS /jobs/<id>` now responds with `200` plus the `Access-Control-Allow-*` headers, exercised by hitting the live signatur indicator after this deploys.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced job API endpoints with CORS preflight support for improved cross-origin request compatibility.

* **Tests**
  * Added test coverage for CORS headers on all job-related endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->